### PR TITLE
added connect and disconnect ability

### DIFF
--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -260,7 +260,7 @@ module Rock
                     
                     desc 'disconnect a port completely'
                     get ':name_service/:name/ports/:port_name/disconnect_all' do
-                        port = port_by_task_and_name(*params.values_at('name_service', 'from', 'port'))
+                        port = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
                         port.disconnect_all    
                     end
                     

--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -258,6 +258,13 @@ module Rock
                         source.disconnect_from target    
                     end
                     
+                    desc 'disconnect a port completely'
+                    get ':name_service/:name/ports/:port_name/disconnect_all' do
+                        port = port_by_task_and_name(*params.values_at('name_service', 'from', 'port'))
+                        port.disconnect_all    
+                    end
+                    
+                    
                 end
             end
         end

--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -230,6 +230,21 @@ module Rock
                         end
                         
                     end
+                    
+                    get ':name_service/:name/ports/:port_name/connect' do
+                        puts "connecting to #{request.params["to"]}"
+                        target = port_by_task_and_name(*params.values_at('name_service', 'to', 'port'))
+                        source = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
+                        source.connect_to target    
+                    end
+                    
+                    get ':name_service/:name/ports/:port_name/disconnect' do
+                        puts "connecting to #{request.params["from"]}"
+                        target = port_by_task_and_name(*params.values_at('name_service', 'from', 'port'))
+                        source = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
+                        source.disconnect_from target    
+                    end
+                    
                 end
             end
         end

--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -231,15 +231,28 @@ module Rock
                         
                     end
                     
+                    desc 'connect a port, /connect&to=taskname&port=portname, optional &type=buffer&size=10'
+                    params do
+                        requires :to, :port
+                        optional :type, type: String, default: "data"
+                        optional :size, type: Integer, default: 10
+                    end
                     get ':name_service/:name/ports/:port_name/connect' do
-                        puts "connecting to #{request.params["to"]}"
                         target = port_by_task_and_name(*params.values_at('name_service', 'to', 'port'))
-                        source = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
-                        source.connect_to target    
+                        source = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))                        
+                        if request.params["type"] == "buffer"
+                            source.connect_to target, :type => :buffer, :size => request.params["size"]
+                        else
+                            source.connect_to target    
+                        end
+                         
                     end
                     
+                    desc 'disconnect a port /disconnect&from=taskname&port=portname'
+                    params do
+                        requires :from, :name
+                    end
                     get ':name_service/:name/ports/:port_name/disconnect' do
-                        puts "connecting to #{request.params["from"]}"
                         target = port_by_task_and_name(*params.values_at('name_service', 'from', 'port'))
                         source = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
                         source.disconnect_from target    


### PR DESCRIPTION
Hi, this functionality is needed to switch configurations for e.g. autonomous control and remote via webapps. For this the trajectory_follower has te be disconnected from the motion2d command port, and also has to be reconnected afterwards.

The urls are like this
[..]/TASKNAME/ports/PORTNAME/connect?to=TASKNAME&port=PORTNAME
[..]/TASKNAME/ports/PORTNAME/disconnect?from=TASKNAME&port=PORTNAME

I've chosen to use GET as it is easier to use these commands, for example in normal http links, rather than using an <form> html element
