### PR TITLE
added start/stop/configure/cleanup functionality

### DIFF
--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -342,7 +342,7 @@ module Rock
                         action = params[:action]
                         #check for allowed actions for securiry reasons
                         #otherwise all the tasks methods could be called using this interface
-                        if ['start', 'stop', 'configure', 'cleanup'].include? action
+                        if ['start', 'stop', 'configure', 'cleanup', 'reset_exception'].include? action
                             begin
                                 task.send(action)
                                 return true

--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -102,6 +102,55 @@ module Rock
                         Hash[task: task_by_name(params[:name_service], params[:name]).to_h]
                     end
                     
+                    desc "starts a task"
+                    get ':name_service/:name/start' do
+                        task = task_by_name(params[:name_service], params[:name])
+                        begin
+                            task.start
+                            return task.rtt_state == :RUNNING
+                        rescue Orocos::StateTransitionFailed => exception
+                            puts exception.pretty_inspect
+                            error! "#{exception}" ,405
+                        end
+
+                    end
+                    
+                    desc "stop a task"
+                    get ':name_service/:name/stop' do
+                        task = task_by_name(params[:name_service], params[:name])
+                        begin
+                            task.stop
+                            return task.rtt_state == :STOPPED
+                        rescue Orocos::StateTransitionFailed => exception
+                            puts exception.pretty_inspect
+                            error! "#{exception}" ,405
+                        end
+                    end
+                    
+                    desc "configure a task"
+                    get ':name_service/:name/configure' do
+                        task = task_by_name(params[:name_service], params[:name])
+                        begin
+                            task.configure
+                            return task.rtt_state == :STOPPED
+                        rescue Orocos::StateTransitionFailed => exception
+                            puts exception.pretty_inspect
+                            error! "#{exception}" ,405
+                        end
+                    end
+                    
+                    desc "cleanup a task"
+                    get ':name_service/:name/cleanup' do
+                        task = task_by_name(params[:name_service], params[:name])
+                        begin
+                            task.cleanup
+                            return task.rtt_state == :PRE_OPERATIONAL
+                        rescue Orocos::StateTransitionFailed => exception
+                            puts exception.pretty_inspect
+                            error! "#{exception}" ,405
+                        end
+                    end
+                    
                     desc "returns information about the properties of a given task"
                     get ':name_service/:name/properties' do
                         task = task_by_name(params[:name_service], params[:name])

--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -334,7 +334,7 @@ module Rock
                         end  
                     end
                     
-                    desc "management for running tasks ('start', 'stop', 'configure', 'cleanup')"
+                    desc "management for running tasks ('start', 'stop', 'configure', 'cleanup', 'reset_exception')"
                     # has to be defined after other requests e.g. ':name_service/:name/properties' or ':name_service/:name/ports'
                     # in order to be evalueated after them, otherwise this would catch the other requests and return false  
                     get ':name_service/:name/:action' do
@@ -345,7 +345,6 @@ module Rock
                         if ['start', 'stop', 'configure', 'cleanup', 'reset_exception'].include? action
                             begin
                                 task.send(action)
-                                return true
                             rescue Orocos::StateTransitionFailed => exception
                                 error! "#{exception}" ,405
                             end


### PR DESCRIPTION
I hope I got the allowed state transitions right, the ruby start/stop/configure/cleanup functions only return nil but I wanted to provide a value whether the transition was successful or not, so i use rtt_state to check a valid transition.

There are no tests available as rtt_state is not available for ruby tasks and using flexmock to mimic states does not give valid information as the error may be in the api or flexmock implementation -> a test would prove nothing.
