### PR TITLE
bugfix: properly validate :name_service url property when it contains dots (127.0.0.1 / robot.local)

### DIFF
--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -3,7 +3,7 @@ require 'rock/webapp/tasks/cached_ports'
 module Rock
     module WebApp
         module Tasks    
-            
+                      
             class API < Grape::API
                 version 'v1', using: :header, vendor: :rock
                 format :json
@@ -15,6 +15,8 @@ module Rock
                     @ports
                 end
                 
+                #http://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
+                ValidHostnameRegex = /(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])/
                 
                 def self.stream_async_data_to_websocket(env, data_source, count = Float::INFINITY, binary)
                     emitted_samples = 0
@@ -96,27 +98,27 @@ module Rock
                         end
                         
                     end
-    
+                   
                     desc "Lists information about a given task"
-                    get ':name_service/:name' do
+                    get ':name_service/:name', :requirements => { :name_service => ValidHostnameRegex } do
                         Hash[task: task_by_name(params[:name_service], params[:name]).to_h]
                     end
                     
                     desc "returns information about the properties of a given task"
-                    get ':name_service/:name/properties' do
+                    get ':name_service/:name/properties', :requirements => { :name_service => ValidHostnameRegex } do
                         task = task_by_name(params[:name_service], params[:name])
                         Hash[properties: task.property_names]
                     end
                                     
                     desc "read the seleted property"
-                    get ':name_service/:name/properties/:property_name/read' do
+                    get ':name_service/:name/properties/:property_name/read', :requirements => { :name_service => ValidHostnameRegex } do
                         task = task_by_name(params[:name_service], params[:name])
                         prop = task.property(params[:property_name])
                         Hash[value: prop.raw_read.to_json_value(special_float_values: :string)]
                     end
                     
                     desc "writes a property"
-                    post ':name_service/:name/properties/:property_name/write' do
+                    post ':name_service/:name/properties/:property_name/write', :requirements => { :name_service => ValidHostnameRegex } do
                         task = task_by_name(params[:name_service], params[:name])
                         prop = task.property(params[:property_name])
                             
@@ -136,13 +138,13 @@ module Rock
                     end
     
                     desc "Lists all ports of the task"
-                    get ':name_service/:name/ports' do
+                    get ':name_service/:name/ports', :requirements => { :name_service => ValidHostnameRegex } do
                         task = task_by_name(params[:name_service], params[:name])
                         Hash[ports: task.port_names]
                     end
                     
                     desc "returns information about the given port"
-                    get ':name_service/:name/ports/:port_name' do
+                    get ':name_service/:name/ports/:port_name', :requirements => { :name_service => ValidHostnameRegex } do
                         port = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
                         Hash[port: port.model.to_h]
                     end
@@ -155,7 +157,7 @@ module Rock
                         optional :binary, type: Boolean, default: false
                         optional :init, type: Boolean, default: false
                     end
-                    get ':name_service/:name/ports/:port_name/read' do
+                    get ':name_service/:name/ports/:port_name/read', :requirements => { :name_service => ValidHostnameRegex } do
                         
                         port = get_port(*params.values_at('name_service', 'name', 'port_name', 'init', 'timeout'))
                         #port = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
@@ -194,7 +196,7 @@ module Rock
                     end
 
                     desc "get a json value, which can be re-written to the port (no need to generate from port info)"
-                    get ':name_service/:name/ports/:port_name/sample' do
+                    get ':name_service/:name/ports/:port_name/sample', :requirements => { :name_service => ValidHostnameRegex } do
                         
                         writer = get_port(*params.values_at('name_service', 'name', 'port_name', 'timeout'))
                             
@@ -211,7 +213,7 @@ module Rock
                     params do
                         optional :timeout, type: Integer, default: 30
                     end
-                    post ':name_service/:name/ports/:port_name/write' do
+                    post ':name_service/:name/ports/:port_name/write', :requirements => { :name_service => ValidHostnameRegex } do
  
                         writer = get_port(*params.values_at('name_service', 'name', 'port_name', 'timeout'))
     
@@ -238,7 +240,7 @@ module Rock
                     desc "write a value to a port using a ws"
                     #ws is using a get request, so we can't combine with the post url
                     #bit we can use the same, because it starts with ws://
-                    get ':name_service/:name/ports/:port_name/write' do
+                    get ':name_service/:name/ports/:port_name/write', :requirements => { :name_service => ValidHostnameRegex } do
                         
                         if Faye::WebSocket.websocket?(env)
                             writer = get_port(*params.values_at('name_service', 'name', 'port_name'),false,0)
@@ -263,7 +265,7 @@ module Rock
                         optional :type, type: String, default: "data"
                         optional :size, type: Integer, default: 10
                     end
-                    get ':name_service/:name/ports/:port_name/connect' do
+                    get ':name_service/:name/ports/:port_name/connect', :requirements => { :name_service => ValidHostnameRegex } do
                         target = port_by_task_and_name(*params.values_at('name_service', 'to', 'port'))
                         source = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))                        
                         if request.params["type"] == "buffer"
@@ -278,28 +280,28 @@ module Rock
                     params do
                         requires :from, :name
                     end
-                    get ':name_service/:name/ports/:port_name/disconnect' do
+                    get ':name_service/:name/ports/:port_name/disconnect', :requirements => { :name_service => ValidHostnameRegex } do
                         target = port_by_task_and_name(*params.values_at('name_service', 'from', 'port'))
                         source = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
                         source.disconnect_from target    
                     end
                     
                     desc 'disconnect a port completely'
-                    get ':name_service/:name/ports/:port_name/disconnect_all' do
+                    get ':name_service/:name/ports/:port_name/disconnect_all', :requirements => { :name_service => ValidHostnameRegex } do
                         port = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
                         port.disconnect_all    
                     end
                     
                     
                     desc 'list operations'
-                    get ':name_service/:name/operations/' do
+                    get ':name_service/:name/operations/', :requirements => { :name_service => ValidHostnameRegex } do
                         taskhash = Hash[task_by_name(params[:name_service], params[:name]).to_h]
                         model = taskhash[:model]
                         Hash[operations: model[:operations]]
                     end
                     
                     desc 'get operation parameters sample'
-                    get ':name_service/:name/operations/:operation/example_arguments' do
+                    get ':name_service/:name/operations/:operation/example_arguments', :requirements => { :name_service => ValidHostnameRegex } do
                         op = get_operation(params[:name_service], params[:name],params[:operation])
                         paramarray = Array.new 
                         op.arguments_types.each do |elem|
@@ -310,7 +312,7 @@ module Rock
                     end
                     
                     desc 'run operation'
-                    post ':name_service/:name/operations/:operation' do
+                    post ':name_service/:name/operations/:operation', :requirements => { :name_service => ValidHostnameRegex } do
                         op = get_operation(params[:name_service], params[:name],params[:operation])
                             
                         begin
@@ -333,7 +335,7 @@ module Rock
                             error! "unable to write to call operation #{ex}", 404
                         end  
                     end
-                    
+
                     desc "management for running tasks ('start', 'stop', 'configure', 'cleanup', 'reset_exception')"
                     # has to be defined after other requests e.g. ':name_service/:name/properties' or ':name_service/:name/ports'
                     # in order to be evalueated after them, otherwise this would catch the other requests and return false  
@@ -352,7 +354,7 @@ module Rock
                             error! "Method '#{action}' on task '#{params[:name_service]}/#{params[:name]}' is not allowed to be called using the rest api" ,405
                         end
                     end
-                    
+
                 end
             end
         end

--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -2,28 +2,27 @@ require 'rock/webapp/tasks/cached_ports'
 
 module Rock
     module WebApp
-        module Tasks    
-                      
+        module Tasks
+
             class API < Grape::API
                 version 'v1', using: :header, vendor: :rock
                 format :json
-    
-                
+
                 @ports = CachedPorts.new
-                
+
                 def self.ports
                     @ports
                 end
-                
+
                 #http://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
                 ValidHostnameRegex = /(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])/
-                
+
                 def self.stream_async_data_to_websocket(env, data_source, count = Float::INFINITY, binary)
                     emitted_samples = 0
-    
+
                     # Asynchronous streaming mode
                     ws = Faye::WebSocket.new(env)
-    
+
                     listener = data_source.on_raw_data do |sample|
                         result = nil
                         if binary
@@ -31,7 +30,7 @@ module Rock
                         else
                             result = Hash[value: sample.to_json_value(special_float_values: :string)]    
                         end
-                        
+
                         if !ws.send(MultiJson.dump(result))
                             WebApp.warn "failed to send, closing connection"
                             ws.close
@@ -44,14 +43,14 @@ module Rock
                             listener.stop
                         end
                     end
-    
+
                     ws.on :close do |event|
                         listener.stop
                     end
-    
+
                     ws
                 end
-                
+
                 resource :tasks do
                     desc "Lists all tasks that are currently reachable on the name services"
                     params do
@@ -64,7 +63,7 @@ module Rock
                             Hash[task_names: Orocos.name_service.names]
                         end
                     end
-    
+
                     helpers do
                         def task_by_name(name_service, name)
                             if name_service == '*'
@@ -75,13 +74,13 @@ module Rock
                         rescue Orocos::NotFound
                             error! "cannot find task #{name_service}/#{name} on the registered name services", 404
                         end
-    
+
                         def port_by_task_and_name(name_service, name, port_name)
                             task_by_name(name_service, name).port(port_name)
                         rescue Orocos::NotFound
                             error! "cannot find port #{port_name} on task #{name_service}/#{name}", 404
                         end
-                        
+
                         def get_port(name_service, name, port_name, init = false, timeout = 30)
                             portentry = API.ports.get(name_service, name, port_name, timeout)
                             if !portentry
@@ -90,65 +89,65 @@ module Rock
                             end
                             portentry
                         end
-                        
+
                         def get_operation(name_service, name, operation_name)
                             task_by_name(name_service, name).operation(operation_name)
                          rescue Orocos::NotFound
                             error! "cannot find operation #{operation_name} on task #{name_service}/#{name}", 404
                         end
-                        
+
                     end
-                   
+
                     desc "Lists information about a given task"
-                    get ':name_service/:name', :requirements => { :name_service => ValidHostnameRegex } do
+                    get ':name_service/:name', requirements: { name_service: ValidHostnameRegex } do
                         Hash[task: task_by_name(params[:name_service], params[:name]).to_h]
                     end
-                    
+
                     desc "returns information about the properties of a given task"
-                    get ':name_service/:name/properties', :requirements => { :name_service => ValidHostnameRegex } do
+                    get ':name_service/:name/properties', requirements: { name_service: ValidHostnameRegex } do
                         task = task_by_name(params[:name_service], params[:name])
                         Hash[properties: task.property_names]
                     end
-                                    
+
                     desc "read the seleted property"
-                    get ':name_service/:name/properties/:property_name/read', :requirements => { :name_service => ValidHostnameRegex } do
+                    get ':name_service/:name/properties/:property_name/read', requirements: { name_service: ValidHostnameRegex } do
                         task = task_by_name(params[:name_service], params[:name])
                         prop = task.property(params[:property_name])
                         Hash[value: prop.raw_read.to_json_value(special_float_values: :string)]
                     end
-                    
+
                     desc "writes a property"
-                    post ':name_service/:name/properties/:property_name/write', :requirements => { :name_service => ValidHostnameRegex } do
+                    post ':name_service/:name/properties/:property_name/write', requirements: { name_service: ValidHostnameRegex } do
                         task = task_by_name(params[:name_service], params[:name])
                         prop = task.property(params[:property_name])
-                            
+
                         begin
                             obj = MultiJson.load(request.params["value"])
                         rescue MultiJson::ParseError => exception
                             error! "malformed JSON string: #{request.params["value"]}", 415
-                        end 
-                                             
+                        end
+
                         begin
                             return prop.write(obj["value"])
                         rescue Typelib::UnknownConversionRequested => exception
                             error! "property type mismatch", 406
                         rescue Exception => ex
                             error! "unable to write to property #{ex}", 404
-                        end  
+                        end
                     end
-    
+
                     desc "Lists all ports of the task"
-                    get ':name_service/:name/ports', :requirements => { :name_service => ValidHostnameRegex } do
+                    get ':name_service/:name/ports', requirements: { name_service: ValidHostnameRegex } do
                         task = task_by_name(params[:name_service], params[:name])
                         Hash[ports: task.port_names]
                     end
-                    
+
                     desc "returns information about the given port"
-                    get ':name_service/:name/ports/:port_name', :requirements => { :name_service => ValidHostnameRegex } do
+                    get ':name_service/:name/ports/:port_name', requirements: { name_service: ValidHostnameRegex } do
                         port = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
                         Hash[port: port.model.to_h]
                     end
-    
+
                     desc 'read a sample on the given port and returns it'
                     params do
                         optional :timeout, type: Float, default: 2.0
@@ -157,15 +156,15 @@ module Rock
                         optional :binary, type: Boolean, default: false
                         optional :init, type: Boolean, default: false
                     end
-                    get ':name_service/:name/ports/:port_name/read', :requirements => { :name_service => ValidHostnameRegex } do
-                        
+                    get ':name_service/:name/ports/:port_name/read', requirements: { name_service: ValidHostnameRegex } do
+
                         port = get_port(*params.values_at('name_service', 'name', 'port_name', 'init', 'timeout'))
                         #port = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
-    
+
                         if !port.is_reader?
                             error! "#{port.name} is an input port, cannot read"
                         end
-                        
+
                         if Faye::WebSocket.websocket?(env)
                             port = port.port.to_async.reader(init: true, pull: true)
                             count = params.fetch(:count, Float::INFINITY)
@@ -173,7 +172,7 @@ module Rock
                             status, response = ws.rack_response
                             status status
                             response
-                            
+
                         else # Direct polling mode
                             count = params.fetch(:count, 1)
                             reader = port.reader
@@ -196,37 +195,31 @@ module Rock
                     end
 
                     desc "get a json value, which can be re-written to the port (no need to generate from port info)"
-                    get ':name_service/:name/ports/:port_name/sample', :requirements => { :name_service => ValidHostnameRegex } do
-                        
+                    get ':name_service/:name/ports/:port_name/sample', requirements: { name_service: ValidHostnameRegex } do
                         writer = get_port(*params.values_at('name_service', 'name', 'port_name', 'timeout'))
-                            
                         if !writer.is_writer?
                             error! "#{port.name} is an output port, cannot create a empty sample, use read instead" , 403
-                        end 
-                        
+                        end
                         sample = writer.writer.new_sample.zero!
                         Hash[:value => sample.to_json_value]
                     end
-                    
-                                       
+
                     desc "write a value to a port"
                     params do
                         optional :timeout, type: Integer, default: 30
                     end
-                    post ':name_service/:name/ports/:port_name/write', :requirements => { :name_service => ValidHostnameRegex } do
- 
+                    post ':name_service/:name/ports/:port_name/write', requirements: { name_service: ValidHostnameRegex } do
                         writer = get_port(*params.values_at('name_service', 'name', 'port_name', 'timeout'))
-    
                         if !writer.is_writer?
                             error! "#{port.name} is an output port, cannot write" , 403
-                        end 
-                        
+                        end
+
                         begin
                             obj = MultiJson.load(request.params["value"])
                         rescue MultiJson::ParseError => exception
                             error! "malformed JSON string: #{request.params["value"]}", 415
-                        end 
-                                             
+                        end
+
                         begin
                             writer.write(obj,params[:timeout])
                         rescue Typelib::UnknownConversionRequested => exception
@@ -234,14 +227,13 @@ module Rock
                         rescue Exception => ex
                             #puts ex
                             error! "unable to write to port #{ex}", 404
-                        end  
+                        end
                     end
-                    
+
                     desc "write a value to a port using a ws"
                     #ws is using a get request, so we can't combine with the post url
                     #bit we can use the same, because it starts with ws://
-                    get ':name_service/:name/ports/:port_name/write', :requirements => { :name_service => ValidHostnameRegex } do
-                        
+                    get ':name_service/:name/ports/:port_name/write', requirements: { name_service: ValidHostnameRegex } do
                         if Faye::WebSocket.websocket?(env)
                             writer = get_port(*params.values_at('name_service', 'name', 'port_name'),false,0)
                             ws = Faye::WebSocket.new(env)
@@ -256,71 +248,69 @@ module Rock
                             status status
                             response
                         end
-                        
                     end
-                    
+
                     desc 'connect a port, /connect&to=taskname&port=portname, optional &type=buffer&size=10'
                     params do
                         requires :to, :port
                         optional :type, type: String, default: "data"
                         optional :size, type: Integer, default: 10
                     end
-                    get ':name_service/:name/ports/:port_name/connect', :requirements => { :name_service => ValidHostnameRegex } do
+                    get ':name_service/:name/ports/:port_name/connect', requirements: { name_service: ValidHostnameRegex } do
                         target = port_by_task_and_name(*params.values_at('name_service', 'to', 'port'))
                         source = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))                        
                         if request.params["type"] == "buffer"
                             source.connect_to target, :type => :buffer, :size => request.params["size"]
                         else
-                            source.connect_to target    
+                            source.connect_to target
                         end
-                         
+
                     end
-                    
+
                     desc 'disconnect a port /disconnect&from=taskname&port=portname'
                     params do
                         requires :from, :name
                     end
-                    get ':name_service/:name/ports/:port_name/disconnect', :requirements => { :name_service => ValidHostnameRegex } do
+                    get ':name_service/:name/ports/:port_name/disconnect', requirements: { name_service: ValidHostnameRegex } do
                         target = port_by_task_and_name(*params.values_at('name_service', 'from', 'port'))
                         source = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
-                        source.disconnect_from target    
+                        source.disconnect_from target
                     end
-                    
+
                     desc 'disconnect a port completely'
-                    get ':name_service/:name/ports/:port_name/disconnect_all', :requirements => { :name_service => ValidHostnameRegex } do
+                    get ':name_service/:name/ports/:port_name/disconnect_all', requirements: { name_service: ValidHostnameRegex } do
                         port = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
-                        port.disconnect_all    
+                        port.disconnect_all
                     end
-                    
-                    
+
                     desc 'list operations'
-                    get ':name_service/:name/operations/', :requirements => { :name_service => ValidHostnameRegex } do
+                    get ':name_service/:name/operations/', requirements: { name_service: ValidHostnameRegex } do
                         taskhash = Hash[task_by_name(params[:name_service], params[:name]).to_h]
                         model = taskhash[:model]
                         Hash[operations: model[:operations]]
                     end
-                    
+
                     desc 'get operation parameters sample'
-                    get ':name_service/:name/operations/:operation/example_arguments', :requirements => { :name_service => ValidHostnameRegex } do
+                    get ':name_service/:name/operations/:operation/example_arguments', requirements: { name_service: ValidHostnameRegex } do
                         op = get_operation(params[:name_service], params[:name],params[:operation])
-                        paramarray = Array.new 
+                        paramarray = Array.new
                         op.arguments_types.each do |elem|
                             entry = elem.new.zero!
                             paramarray << entry.to_json_value(special_float_values: :string)
                         end
                         Hash[:args => paramarray]
                     end
-                    
+
                     desc 'run operation'
-                    post ':name_service/:name/operations/:operation', :requirements => { :name_service => ValidHostnameRegex } do
+                    post ':name_service/:name/operations/:operation', requirements: { name_service: ValidHostnameRegex } do
                         op = get_operation(params[:name_service], params[:name],params[:operation])
-                            
+
                         begin
                             obj = MultiJson.load(request.params["value"])
                         rescue MultiJson::ParseError => exception
                             error! "malformed JSON string: #{request.params["value"]}", 415
                         end
-                        
+
                         begin
                             params = obj["args"]
                             result=op.callop(*params)
@@ -333,7 +323,7 @@ module Rock
                             error! "argument type mismatch" , 406
                         rescue Exception => ex
                             error! "unable to write to call operation #{ex}", 404
-                        end  
+                        end
                     end
 
                     desc "management for running tasks ('start', 'stop', 'configure', 'cleanup', 'reset_exception')"

--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -15,7 +15,7 @@ module Rock
                 end
 
                 #http://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
-                ValidHostnameRegex = /(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])/
+                ValidHostnameRegex = /\*|(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])/
 
                 def self.stream_async_data_to_websocket(env, data_source, count = Float::INFINITY, binary)
                     emitted_samples = 0
@@ -198,7 +198,7 @@ module Rock
                     get ':name_service/:name/ports/:port_name/sample', requirements: { name_service: ValidHostnameRegex } do
                         writer = get_port(*params.values_at('name_service', 'name', 'port_name', 'timeout'))
                         if !writer.is_writer?
-                            error! "#{port.name} is an output port, cannot create a empty sample, use read instead" , 403
+                            error! "#{writer.name} is an output port, cannot create a empty sample, use read instead" , 403
                         end
                         sample = writer.writer.new_sample.zero!
                         Hash[:value => sample.to_json_value]
@@ -211,7 +211,7 @@ module Rock
                     post ':name_service/:name/ports/:port_name/write', requirements: { name_service: ValidHostnameRegex } do
                         writer = get_port(*params.values_at('name_service', 'name', 'port_name', 'timeout'))
                         if !writer.is_writer?
-                            error! "#{port.name} is an output port, cannot write" , 403
+                            error! "#{writer.name} is an output port, cannot write" , 403
                         end
 
                         begin

--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -329,7 +329,7 @@ module Rock
                     desc "management for running tasks ('start', 'stop', 'configure', 'cleanup', 'reset_exception')"
                     # has to be defined after other requests e.g. ':name_service/:name/properties' or ':name_service/:name/ports'
                     # in order to be evalueated after them, otherwise this would catch the other requests and return false  
-                    get ':name_service/:name/:action' do
+                    get ':name_service/:name/:action', requirements: { name_service: ValidHostnameRegex } do
                         task = task_by_name(params[:name_service], params[:name])
                         action = params[:action]
                         #check for allowed actions for securiry reasons


### PR DESCRIPTION
name services were not possible when they were ips or other host names containing dots.
