### PR TITLE
add hostname support for connect and disconnect

### DIFF
--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -250,29 +250,49 @@ module Rock
                         end
                     end
 
-                    desc 'connect a port, /connect&to=taskname&port=portname, optional &type=buffer&size=10'
+                    desc 'connect a port, /connect&to=hostname/taskname&port=portname&host=hostname, optional &type=buffer&size=10'
                     params do
                         requires :to, :port
                         optional :type, type: String, default: "data"
                         optional :size, type: Integer, default: 10
                     end
                     get ':name_service/:name/ports/:port_name/connect', requirements: { name_service: ValidHostnameRegex } do
-                        target = port_by_task_and_name(*params.values_at('name_service', 'to', 'port'))
+                        hostname = "*"
+                        #check if "to" contains '/'
+                        taskinfo = params["to"].split('/')
+                        if taskinfo.size() == 2
+                           #there was a / present
+                           hostname=taskinfo[0]
+                           taskname=taskinfo[1]
+                        elsif taskinfo.size == 1
+                           taskname = taskinfo[0]
+                        end
+                        target = port_by_task_and_name(hostname, taskname, params["port"])
                         source = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))                        
                         if request.params["type"] == "buffer"
-                            source.connect_to target, :type => :buffer, :size => request.params["size"]
+                            res = source.connect_to target, :type => :buffer, :size => request.params["size"]
                         else
-                            source.connect_to target
+                            res =source.connect_to target
                         end
-
+                        res
                     end
 
-                    desc 'disconnect a port /disconnect&from=taskname&port=portname'
+                    desc 'disconnect a port /disconnect&from=hostname/taskname&port=portname&host=hostname'
                     params do
-                        requires :from, :name
+                        requires :from, :port
                     end
                     get ':name_service/:name/ports/:port_name/disconnect', requirements: { name_service: ValidHostnameRegex } do
-                        target = port_by_task_and_name(*params.values_at('name_service', 'from', 'port'))
+                        hostname = "*"
+                        #check if "to" contains '/'
+                        taskinfo = params["from"].split('/')
+                        if taskinfo.size() == 2
+                           #there was a / present
+                           hostname=taskinfo[0]
+                           taskname=taskinfo[1]
+                        elsif taskinfo.size == 1
+                           taskname = taskinfo[0]
+                        end
+                        target = port_by_task_and_name(hostname, taskname, params['port'])
                         source = port_by_task_and_name(*params.values_at('name_service', 'name', 'port_name'))
                         source.disconnect_from target
                     end

--- a/lib/rock/webapp/tasks/api.rb
+++ b/lib/rock/webapp/tasks/api.rb
@@ -250,7 +250,7 @@ module Rock
                         end
                     end
 
-                    desc 'connect a port, /connect&to=hostname/taskname&port=portname&host=hostname, optional &type=buffer&size=10'
+                    desc 'connect a port, /connect&to=name_service/taskname&port=portname, optional &type=buffer&size=10'
                     params do
                         requires :to, :port
                         optional :type, type: String, default: "data"
@@ -277,7 +277,7 @@ module Rock
                         res
                     end
 
-                    desc 'disconnect a port /disconnect&from=hostname/taskname&port=portname&host=hostname'
+                    desc 'disconnect a port /disconnect&from=name_service/taskname&port=portname'
                     params do
                         requires :from, :port
                     end


### PR DESCRIPTION
Opted to name the option "host" instead of "name_service" as it is similar to the start command line of the api.
